### PR TITLE
Switch to robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["algorithms", "mathematics", "game-development"]
 
 [dependencies]
 glam = "0.27"
+robust = "1.1.0"
 
 [dev-dependencies]
 bevy = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ glam = "0.27"
 
 [dev-dependencies]
 bevy = "0.14"
+rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ robust = "1.1.0"
 [dev-dependencies]
 bevy = "0.14"
 rand = "0.8.5"
+
+[profile.bench]
+debug = true

--- a/examples/3d_shapes.rs
+++ b/examples/3d_shapes.rs
@@ -229,8 +229,7 @@ fn render_convex_hulls(
             .map(|v| Vec3::from(*v).as_dvec3())
             .collect::<Vec<_>>();
 
-        let Ok(hull) = ConvexHull::try_new(&positions, None, None).map_err(|e| warn!("{:?}", e))
-        else {
+        let Ok(hull) = ConvexHull::try_new(&positions, None).map_err(|e| warn!("{:?}", e)) else {
             continue;
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,10 +114,8 @@ impl ConvexHull {
             return Err(ErrorKind::Degenerated);
         }
 
-        let ((min_point, min_indices), (max_point, max_indices)) = Self::compute_extremes(points);
-
         // Create the initial simplex, a tetrahedron in 3D.
-        let mut c_hull = Self::init_tetrahedron(points, min_indices, max_indices)?;
+        let mut c_hull = Self::init_tetrahedron(points)?;
 
         // Run the main quick hull algorithm.
         c_hull.update(max_iter)?;
@@ -134,7 +132,7 @@ impl ConvexHull {
 
     /// Computes the minimum and maximum extents for the given point set, along with
     /// the indices of the minimum and maximum vertices along each coordinate axis.
-    fn compute_extremes(points: &[DVec3]) -> ((DVec3, [usize; 3]), (DVec3, [usize; 3])) {
+    fn compute_extremes(points: &[DVec3]) -> ([usize; 3], [usize; 3]) {
         let mut min = points[0];
         let mut max = points[0];
 
@@ -167,14 +165,14 @@ impl ConvexHull {
             }
         }
 
-        ((min, min_vertices), (max, max_vertices))
+        (min_vertices, max_vertices)
     }
 
     fn init_tetrahedron(
         points: &[DVec3],
-        min_indices: [usize; 3],
-        max_indices: [usize; 3],
     ) -> Result<Self, ErrorKind> {
+
+        let (min_indices, max_indices) = Self::compute_extremes(points);
         // Get the indices of the vertices used for the initial tetrahedron.
         let indices_set = Self::init_tetrahedron_indices(points, min_indices, max_indices)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,10 +778,31 @@ fn compute_horizon(
     Ok(horizon)
 }
 
+trait ToRobust {
+    fn to_robust(self) -> robust::Coord3D<f64>;
+}
+
+impl ToRobust for glam::DVec3 {
+    fn to_robust(self) -> robust::Coord3D<f64> {
+        let DVec3 { x, y, z } = self;
+        robust::Coord3D { x, y, z }
+    }
+}
+
 fn position_from_face(points: &[DVec3], face: &Face, point_index: usize) -> f64 {
-    let origin = face.distance_from_origin;
-    let pos = face.normal.dot(points[point_index]);
-    pos - origin
+    let face_points = face
+        .indices
+        .iter()
+        .copied()
+        .map(|i| points[i])
+        .collect::<Vec<_>>();
+
+    -robust::orient3d(
+        face_points[0].to_robust(),
+        face_points[1].to_robust(),
+        face_points[2].to_robust(),
+        points[point_index].to_robust(),
+    )
 }
 
 fn is_on_positive_side(point: DVec3, normal: DVec3, plane_distance: f64) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use glam::{DMat4, DVec3};
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
-use std::f64::consts::PI;
 use std::fmt;
 
 /// A polygonal face belonging to a [`ConvexHull`].
@@ -603,7 +602,7 @@ impl ConvexHull {
 
     /// Computes the volume of the convex hull.
     /// Sums up volumes of tetrahedrons from an arbitrary point to all other points
-    /// 
+    ///
     /// Returns non-negative value, for extremely small objects might return 0.0
     pub fn volume(&self) -> f64 {
         let (hull_vertices, hull_indices) = self.vertices_indices();
@@ -930,7 +929,7 @@ fn sphere_volume_test() {
     let points = sphere_points(50);
     let hull = ConvexHull::try_new(&points, None).unwrap();
     let volume = hull.volume();
-    let expected_volume = 4.0 / 3.0 * PI;
+    let expected_volume = 4.0 / 3.0 * std::f64::consts::PI;
     assert!(
         (volume - expected_volume).abs() < 0.1,
         "Expected {expected_volume}, got {volume}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -775,9 +775,6 @@ fn position_from_face(points: &[DVec3], face: &Face, point_index: usize) -> f64 
     )
 }
 
-fn is_on_positive_side(point: DVec3, normal: DVec3, plane_distance: f64) -> bool {
-    normal.dot(point) + plane_distance >= 0.0
-}
 
 /// Computes the normal of a triangle face with a counterclockwise orientation.
 fn triangle_normal([a, b, c]: [DVec3; 3]) -> DVec3 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1004,7 +1004,6 @@ fn sphere_test() {
 }
 
 #[test]
-#[ignore]
 fn heavy_sphere_test() {
     fn rot_z(point: DVec3, angle: f64) -> DVec3 {
         let e1 = angle.cos() * point[0] - angle.sin() * point[1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,6 +821,18 @@ fn four_points_min_volume() {
 }
 
 #[test]
+fn volume_should_be_positive() {
+    let mut points = (0..4)
+        .map(|_| DVec3::splat(1.0))
+        .collect::<Vec<_>>();
+    points[0].x += 2.0 * f64::EPSILON;
+    points[1].y += 3.0 * f64::EPSILON;
+    points[2].z += 3.0 * f64::EPSILON;
+    let result = ConvexHull::try_new(&points, None);
+    assert!(result.expect("this should compute ok").volume() > 0.0);
+}
+
+#[test]
 fn face_normal_test() {
     let p1 = DVec3::new(-1.0, 0.0, 0.0);
     let p2 = DVec3::new(1.0, 0.0, 0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1008,7 +1008,7 @@ fn sphere_test() {
 fn heavy_sea_urchin_test() {
     use rand::prelude::{Distribution, SeedableRng, SliceRandom};
 
-    // increase this this to ~1000 to gather more samples for a sampling profiler
+    // increase this to ~1000 to gather more samples for a sampling profiler
     let iterations = 1;
 
     for s in 0..iterations {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1004,7 +1004,12 @@ fn sphere_test() {
 }
 
 #[test]
-fn heavy_sphere_test() {
+fn heavy_sea_urchin_test() {
+    use rand::prelude::{Distribution, SeedableRng, SliceRandom};
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    let dist = rand::distributions::Standard;
+
     fn rot_z(point: DVec3, angle: f64) -> DVec3 {
         let e1 = angle.cos() * point[0] - angle.sin() * point[1];
         let e2 = angle.sin() * point[0] + angle.cos() * point[1];
@@ -1026,10 +1031,13 @@ fn heavy_sphere_test() {
         for step_z in 0..dev {
             let angle_z = 2.0 * std::f64::consts::PI * (step_z as f64 / dev as f64);
             let p = rot_z(p, angle_z);
-            points.push(p);
+            let rand_offset: f64 = dist.sample(&mut rng);
+            points.push(p * rand_offset);
         }
     }
-    let (_v, _i) = ConvexHull::try_new(&points, 0.001, None)
+
+    points.shuffle(&mut rng);
+    let (_v, _i) = ConvexHull::try_new(&points, 0.004, None)
         .unwrap()
         .vertices_indices();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,6 +603,8 @@ impl ConvexHull {
 
     /// Computes the volume of the convex hull.
     /// Sums up volumes of tetrahedrons from an arbitrary point to all other points
+    /// 
+    /// Returns non-negative value, for extremely small objects might return 0.0
     pub fn volume(&self) -> f64 {
         let (hull_vertices, hull_indices) = self.vertices_indices();
         let reference_point = hull_vertices[hull_indices[0]].extend(1.0);
@@ -614,7 +616,7 @@ impl ConvexHull {
                 *mat.col_mut(j) = row;
             }
             *mat.col_mut(3) = reference_point;
-            volume += mat.determinant();
+            volume += mat.determinant().max(0.0);
         }
         volume / 6.0
     }
@@ -814,9 +816,9 @@ fn four_points_min_volume() {
 #[test]
 fn volume_should_be_positive() {
     let mut points = (0..4).map(|_| DVec3::splat(1.0)).collect::<Vec<_>>();
-    points[0].x += 2.0 * f64::EPSILON;
-    points[1].y += 3.0 * f64::EPSILON;
-    points[2].z += 3.0 * f64::EPSILON;
+    points[0].x += 1.0 * f64::EPSILON;
+    points[1].y += 1.0 * f64::EPSILON;
+    points[2].z += 2.0 * f64::EPSILON;
     let result = ConvexHull::try_new(&points, None);
     assert!(result.expect("this should compute ok").volume() > 0.0);
 }


### PR DESCRIPTION
Instead of using the tolerance to deal with numerical instabilities,
use the point to plane side detection from the `robust` crate.
This fixes #1 